### PR TITLE
Add support for fallback transitioning.

### DIFF
--- a/src/MDMTransition.h
+++ b/src/MDMTransition.h
@@ -48,6 +48,29 @@ NS_SWIFT_NAME(TransitionWithCustomDuration)
 @end
 
 /**
+ A transition can return an alternative fallback transition instance.
+ */
+NS_SWIFT_NAME(TransitionWithFallback)
+@protocol MDMTransitionWithFallback
+
+/**
+ Asks the receiver to return a transition instance that should be used to drive this transition.
+
+ If nil is returned, then the system transition will be used.
+ If self is returned, then the receiver will be used.
+ If a new instance is returned and the returned instance also conforms to this protocol, the
+ returned instance will be queried for a fallback.
+
+ Will be queried twice. The first time this method is invoked it's possible to return nil. Doing so
+ will result in UIKit taking over the transition and a system transition being used. The second time
+ this method is invoked, the custom transition will already be underway from UIKit's point of view
+ and a nil return value will be treated equivalent to returning self.
+ */
+- (nullable id<MDMTransition>)fallbackTransitionWithContext:(nonnull id<MDMTransitionContext>)context;
+
+@end
+
+/**
  A transition with presentation is able to customize the overall presentation of the transition,
  including adding temporary views and changing the destination frame of the presented view
  controller.

--- a/src/MDMTransitionController.h
+++ b/src/MDMTransitionController.h
@@ -38,4 +38,11 @@ NS_SWIFT_NAME(TransitionController)
  */
 @property(nonatomic, strong, nullable) id<MDMTransition> transition;
 
+/**
+ The active transition instance.
+
+ This may be non-nil while a transition is active.
+ */
+@property(nonatomic, strong, nullable, readonly) id<MDMTransition> activeTransition;
+
 @end

--- a/src/private/MDMPresentationTransitionController.m
+++ b/src/private/MDMPresentationTransitionController.m
@@ -56,6 +56,10 @@
   }
 }
 
+- (id<MDMTransition>)activeTransition {
+  return _context.transition;
+}
+
 #pragma mark - UIViewControllerTransitioningDelegate
 
 // Animated transitions

--- a/src/private/MDMViewControllerTransitionContext.h
+++ b/src/private/MDMViewControllerTransitionContext.h
@@ -33,6 +33,8 @@
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
+@property(nonatomic, strong, nullable) id<MDMTransition> transition;
+
 @property(nonatomic, weak, nullable) id<MDMViewControllerTransitionContextDelegate> delegate;
 
 @end

--- a/src/private/MDMViewControllerTransitionContext.m
+++ b/src/private/MDMViewControllerTransitionContext.m
@@ -19,7 +19,6 @@
 #import "MDMTransition.h"
 
 @implementation MDMViewControllerTransitionContext {
-  id<MDMTransition> _transition;
   id<UIViewControllerContextTransitioning> _transitionContext;
   UIPresentationController *_presentationController;
 }
@@ -43,6 +42,11 @@
     _backViewController = backViewController;
     _foreViewController = foreViewController;
     _presentationController = presentationController;
+
+    _transition = [self fallbackForTransition:_transition];
+  }
+  if (!_transition) {
+    return nil;
   }
   return self;
 }
@@ -118,6 +122,11 @@
     [to.view layoutIfNeeded];
   }
 
+  id<MDMTransition> fallback = [self fallbackForTransition:_transition];
+  if (fallback) {
+    _transition = fallback;
+  }
+
   [self anticipateOnlyExplicitAnimations];
 
   [CATransaction begin];
@@ -149,6 +158,19 @@
       completion:^(BOOL finished) {
         [throwawayView removeFromSuperview];
       }];
+}
+
+- (id<MDMTransition>)fallbackForTransition:(id<MDMTransition>)transition {
+  while ([transition respondsToSelector:@selector(fallbackTransitionWithContext:)]) {
+    id<MDMTransitionWithFallback> withFallback = (id<MDMTransitionWithFallback>)transition;
+
+    id<MDMTransition> fallback = [withFallback fallbackTransitionWithContext:self];
+    if (fallback == transition) {
+      break;
+    }
+    transition = fallback;
+  }
+  return transition;
 }
 
 @end


### PR DESCRIPTION
Fallback transitioning allows a transition to choose not to drive a transition by swapping itself out with another transition instance or a UIKit native transition.

This is commonly used when a transition expects some sort of context to be available, e.g. a context view, and that context is not immediately available. In this case the transition can fall back to a simpler transition or to use the default UIKit transition.

Closes https://github.com/material-motion/transitioning-objc/issues/13