### PR TITLE
Add transition navigation controller delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ commands:
 1. [Architecture](#architecture)
 2. [How to create a simple transition](#how-to-create-a-simple-transition)
 3. [How to customize presentation](#how-to-customize-presentation)
+4. [How to customize navigation controller transitions](#how-to-customize-navigation-controller-transitions)
 
 ### Architecture
 
@@ -246,6 +247,27 @@ extension MyPresentationController: Transition {
     // Your motion...
   }
 }
+```
+
+### How to customize navigation controller transitions
+
+`UINavigationController` ignores the `transitioningDelegate` property on any view
+controller pushed onto or popped off of the stack, instead relying on its delegate instance to
+customize any transitions. This means that our `transitionController`  will be
+ignored by a navigation controller.
+
+In order to customize individual push/pop transitions with the `transitionController`, you
+can make use of the `TransitionNavigationControllerDelegate` singleton class. If you
+assign a shared delegate to your navigation controller's delegate, your navigation controller
+will honor the animation and interaction settings defined by your individual view controller's
+`transitionController`.
+
+```swift
+navigationController.delegate = TransitionNavigationControllerDelegate.sharedDelegate()
+
+// Subsequent pushes and pops will honor the pushed/popped view controller's
+// transitionController settings as though the view controllers were being
+// presented/dismissed.
 ```
 
 ## Contributing

--- a/examples/FadeExample.m
+++ b/examples/FadeExample.m
@@ -53,7 +53,7 @@
 }
 
 + (NSArray<NSString *> *)catalogBreadcrumbs {
-  return @[ @"1. Fade transition (objc)" ];
+  return @[ @"Fade transition (objc)" ];
 }
 
 @end

--- a/examples/NavControllerFadeExample.swift
+++ b/examples/NavControllerFadeExample.swift
@@ -17,10 +17,10 @@
 import UIKit
 import MotionTransitioning
 
-// This example demonstrates the minimal path to building a custom transition using the Motion
-// Transitioning APIs in Swift. The essential steps have been documented below.
+// This example demonstrates how to build a custom UINavigationController transition using the
+// Motion Transitioning APIs in Swift. The essential steps have been documented below.
 
-class FadeExampleViewController: ExampleViewController {
+class NavControllerFadeExampleViewController: ExampleViewController {
 
   func didTap() {
     let modalViewController = ModalViewController()
@@ -32,12 +32,27 @@ class FadeExampleViewController: ExampleViewController {
     // FadeTransition, so we'll make use of that now:
     modalViewController.transitionController.transition = FadeTransition()
 
-    // Note that once we assign the transition object to the view controller, the transition will
-    // govern all subsequent presentations and dismissals of that view controller instance. If we
-    // want to use a different transition (e.g. to use an edge-swipe-to-dismiss transition) then we
-    // can simply change the transition object before initiating the transition.
+    cachedNavDelegate = navigationController?.delegate
 
-    present(modalViewController, animated: true)
+    // In order to customize navigation controller transitions you must implement the necessary
+    // delegate methods. By setting the shared transition navigation controller delegate instance
+    // we're able to customize push/pop transitions using our transitionController.
+
+    navigationController?.delegate = TransitionNavigationControllerDelegate.sharedDelegate()
+
+    navigationController?.pushViewController(modalViewController, animated: true)
+  }
+  private var cachedNavDelegate: UINavigationControllerDelegate?
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    if parent == nil { // Popped off
+      // Restore the previous delegate, if any.
+      navigationController?.delegate = cachedNavDelegate
+
+      cachedNavDelegate = nil
+    }
   }
 
   override func viewDidLoad() {

--- a/examples/NavControllerFadeExample.swift
+++ b/examples/NavControllerFadeExample.swift
@@ -24,6 +24,7 @@ class NavControllerFadeExampleViewController: ExampleViewController {
 
   func didTap() {
     let modalViewController = ModalViewController()
+    modalViewController.title = "Example view controller"
 
     // The transition controller is an associated object on all UIViewController instances that
     // allows you to customize the way the view controller is presented. The primary API on the

--- a/examples/apps/Catalog/TableOfContents.swift
+++ b/examples/apps/Catalog/TableOfContents.swift
@@ -17,13 +17,17 @@
 // MARK: Catalog by convention
 
 extension FadeExampleViewController {
-  class func catalogBreadcrumbs() -> [String] { return ["1. Fade transition"] }
+  class func catalogBreadcrumbs() -> [String] { return ["Fade transition"] }
+}
+
+extension NavControllerFadeExampleViewController {
+  class func catalogBreadcrumbs() -> [String] { return ["Fade transition (nav controller)"] }
 }
 
 extension MenuExampleViewController {
-  class func catalogBreadcrumbs() -> [String] { return ["2. Menu transition"] }
+  class func catalogBreadcrumbs() -> [String] { return ["Menu transition"] }
 }
 
 extension CustomPresentationExampleViewController {
-  class func catalogBreadcrumbs() -> [String] { return ["3. Custom presentation transitions"] }
+  class func catalogBreadcrumbs() -> [String] { return ["Custom presentation transitions"] }
 }

--- a/examples/apps/Catalog/TransitionsCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/TransitionsCatalog.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		667A3F491DEE269400CB3A99 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 667A3F481DEE269400CB3A99 /* Assets.xcassets */; };
 		667A3F4C1DEE269400CB3A99 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 667A3F4A1DEE269400CB3A99 /* LaunchScreen.storyboard */; };
 		667A3F541DEE273000CB3A99 /* TableOfContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667A3F531DEE273000CB3A99 /* TableOfContents.swift */; };
+		66A320FC1F1E716600E2EAC3 /* NavControllerFadeExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CC3D91F1E6F3000B80804 /* NavControllerFadeExample.swift */; };
 		66BBC75E1ED37DAD0015CB9B /* FadeExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BBC75D1ED37DAD0015CB9B /* FadeExample.swift */; };
 		66BBC76D1ED4C8790015CB9B /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BBC7691ED4C8790015CB9B /* ExampleViewController.swift */; };
 		66BBC76E1ED4C8790015CB9B /* ExampleViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BBC76A1ED4C8790015CB9B /* ExampleViews.swift */; };
@@ -56,6 +57,7 @@
 		6629151F1ED5E137002B9A5D /* ModalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
 		662915211ED5F222002B9A5D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../../README.md; sourceTree = "<group>"; };
 		662915221ED64A10002B9A5D /* TransitionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionTests.swift; sourceTree = "<group>"; };
+		664CC3D91F1E6F3000B80804 /* NavControllerFadeExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavControllerFadeExample.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* TransitionsCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TransitionsCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				66BBC7731ED729A70015CB9B /* FadeExample.h */,
 				66BBC7741ED729A70015CB9B /* FadeExample.m */,
 				072A063A1EEE26A900B9B5FC /* MenuExample.swift */,
+				664CC3D91F1E6F3000B80804 /* NavControllerFadeExample.swift */,
 			);
 			name = examples;
 			path = ../..;
@@ -478,6 +481,7 @@
 				072A063B1EEE26A900B9B5FC /* MenuExample.swift in Sources */,
 				66BBC76D1ED4C8790015CB9B /* ExampleViewController.swift in Sources */,
 				667A3F541DEE273000CB3A99 /* TableOfContents.swift in Sources */,
+				66A320FC1F1E716600E2EAC3 /* NavControllerFadeExample.swift in Sources */,
 				66BBC7701ED4C8790015CB9B /* Layout.swift in Sources */,
 				6629151E1ED5E0E0002B9A5D /* CustomPresentationExample.swift in Sources */,
 				66BBC76E1ED4C8790015CB9B /* ExampleViews.swift in Sources */,

--- a/src/MDMTransitionNavigationControllerDelegate.h
+++ b/src/MDMTransitionNavigationControllerDelegate.h
@@ -1,0 +1,57 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ This class provides a singleton implementation of UINavigationControllerDelegate that makes it
+ possible to configure view controller transitions using each view controller's transition
+ controller.
+
+ This class is not meant to be instantiated directly.
+
+ The +delegate should be assigned as the delegate for any UINavigationController instance that
+ wishes to configure transitions using the mdm_transitionController (transitionController in Swift)
+ property on a view controller.
+
+ If a navigation controller already has its own delegate, then that delegate can simply forward
+ the two necessary methods to the +sharedInstance of this class.
+ */
+NS_SWIFT_NAME(TransitionNavigationControllerDelegate)
+@interface MDMTransitionNavigationControllerDelegate : NSObject
+
+/**
+ Use when directly invoking methods.
+
+ Only supported methods are exposed.
+ */
++ (instancetype)sharedInstance;
+
+/**
+ Can be set as a navigation controller's delegate.
+ */
++ (id<UINavigationControllerDelegate>)sharedDelegate;
+
+#pragma mark <UINavigationControllerDelegate> Support
+
+- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController
+                                  animationControllerForOperation:(UINavigationControllerOperation)operation
+                                               fromViewController:(UIViewController *)fromVC
+                                                 toViewController:(UIViewController *)toVC;
+- (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
+                         interactionControllerForAnimationController:(id<UIViewControllerAnimatedTransitioning>)animationController;
+
+@end

--- a/src/MDMTransitionNavigationControllerDelegate.m
+++ b/src/MDMTransitionNavigationControllerDelegate.m
@@ -1,0 +1,84 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMTransitionNavigationControllerDelegate.h"
+
+#import "MDMTransitionContext.h"
+#import "private/MDMPresentationTransitionController.h"
+#import "private/MDMViewControllerTransitionContext.h"
+
+@interface MDMTransitionNavigationControllerDelegate () <UINavigationControllerDelegate>
+@end
+
+@implementation MDMTransitionNavigationControllerDelegate
+
+- (instancetype)init {
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
+
+- (instancetype)initInternally {
+  return [super init];
+}
+
++ (instancetype)sharedInstance {
+  static id sharedInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[self alloc] initInternally];
+  });
+  return sharedInstance;
+}
+
++ (id<UINavigationControllerDelegate>)sharedDelegate {
+  return [self sharedInstance];
+}
+
+#pragma mark - UINavigationControllerDelegate
+
+- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController
+                                  animationControllerForOperation:(UINavigationControllerOperation)operation
+                                               fromViewController:(UIViewController *)fromVC
+                                                 toViewController:(UIViewController *)toVC {
+  id<UIViewControllerAnimatedTransitioning> animator = nil;
+
+  if (operation == UINavigationControllerOperationPush) {
+    animator = [toVC.transitioningDelegate animationControllerForPresentedController:toVC
+                                                                presentingController:fromVC
+                                                                    sourceController:navigationController];
+  } else {
+    animator = [toVC.transitioningDelegate animationControllerForDismissedController:fromVC];
+  }
+
+  if (!animator) {
+    // For some reason UIKit decides to stop responding to edge swipe dismiss gestures when we
+    // customize the navigation controller delegate's animation methods. Clearing the delegate for
+    // the interactive pop gesture recognizer re-enables this edge-swiping behavior.
+    navigationController.interactivePopGestureRecognizer.delegate = nil;
+  }
+
+  return animator;
+}
+
+- (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
+                         interactionControllerForAnimationController:(id<UIViewControllerAnimatedTransitioning>)animationController {
+  if ([animationController conformsToProtocol:@protocol(UIViewControllerInteractiveTransitioning)]) {
+    return (id<UIViewControllerInteractiveTransitioning>)animationController;
+  }
+  return nil;
+}
+
+@end

--- a/src/MDMTransitionNavigationControllerDelegate.m
+++ b/src/MDMTransitionNavigationControllerDelegate.m
@@ -60,7 +60,7 @@
                                                                 presentingController:fromVC
                                                                     sourceController:navigationController];
   } else {
-    animator = [toVC.transitioningDelegate animationControllerForDismissedController:fromVC];
+    animator = [fromVC.transitioningDelegate animationControllerForDismissedController:fromVC];
   }
 
   if (!animator) {

--- a/src/MotionTransitioning.h
+++ b/src/MotionTransitioning.h
@@ -17,4 +17,5 @@
 #import "MDMTransition.h"
 #import "MDMTransitionContext.h"
 #import "MDMTransitionController.h"
+#import "MDMTransitionNavigationControllerDelegate.h"
 #import "UIViewController+TransitionController.h"


### PR DESCRIPTION
This delegate makes it possible to customize UINavigationController transitions using the `transitionController` associated object on each UIViewController that is pushed and popped.

Closes #6.