### PR TITLE
Store the presentation controller as a weak reference.

### DIFF
--- a/src/private/MDMViewControllerTransitionController.m
+++ b/src/private/MDMViewControllerTransitionController.m
@@ -27,7 +27,7 @@
   // a weak reference to the view controller here.
   __weak UIViewController *_associatedViewController;
 
-  UIPresentationController *_presentationController;
+  __weak UIPresentationController *_presentationController;
 
   MDMViewControllerTransitionContext *_context;
   __weak UIViewController *_source;
@@ -93,10 +93,14 @@
     return nil;
   }
   id<MDMTransitionWithPresentation> withPresentation = (id<MDMTransitionWithPresentation>)_transition;
-  _presentationController = [withPresentation presentationControllerForPresentedViewController:presented
-                                                                      presentingViewController:presenting
-                                                                          sourceViewController:source];
-  return _presentationController;
+  UIPresentationController *presentationController =
+      [withPresentation presentationControllerForPresentedViewController:presented
+                                                presentingViewController:presenting
+                                                    sourceViewController:source];
+  // _presentationController is weakly-held, so we have to do this local var dance to keep it
+  // from being nil'd on assignment.
+  _presentationController = presentationController;
+  return presentationController;
 }
 
 #pragma mark - MDMViewControllerTransitionContextDelegate


### PR DESCRIPTION
This resolves a memory leak of presented view controllers caused by transitions that make use of presentation controllers. The transition controller would hold on to the presentation controller, which would hold on to a strong reference of the presented view controller.