### PR TITLE
Add a stock presentation controller implementation.

### DIFF
--- a/src/MDMTransitionNavigationControllerDelegate.m
+++ b/src/MDMTransitionNavigationControllerDelegate.m
@@ -17,7 +17,7 @@
 #import "MDMTransitionNavigationControllerDelegate.h"
 
 #import "MDMTransitionContext.h"
-#import "private/MDMPresentationTransitionController.h"
+#import "private/MDMViewControllerTransitionController.h"
 #import "private/MDMViewControllerTransitionContext.h"
 
 @interface MDMTransitionNavigationControllerDelegate () <UINavigationControllerDelegate>

--- a/src/MDMTransitionPresentationController.h
+++ b/src/MDMTransitionPresentationController.h
@@ -1,0 +1,91 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@protocol MDMTransitionContext;
+@protocol MDMTransitionPresentationAnimationControlling;
+
+NS_SWIFT_NAME(TransitionFrameCalculation)
+typedef CGRect (^MDMTransitionFrameCalculation)(UIPresentationController * _Nonnull);
+
+/**
+ A transition presentation controller implementation that supports animation delegation, a darkened
+ overlay view, and custom presentation frames.
+ 
+ The presentation controller will create and manage the lifecycle of the scrim view, ensuring that
+ it is removed upon a completed dismissal of the presented view controller.
+ */
+NS_SWIFT_NAME(TransitionPresentationController)
+@interface MDMTransitionPresentationController : UIPresentationController
+
+/**
+ Initializes a presentation controller with the standard values and a frame calculation block.
+ 
+ The frame calculation block is expected to return the desired frame of the presented view
+ controller.
+ */
+- (nonnull instancetype)initWithPresentedViewController:(nonnull UIViewController *)presentedViewController
+                               presentingViewController:(nonnull UIViewController *)presentingViewController
+                          calculateFrameOfPresentedView:(nullable MDMTransitionFrameCalculation)calculateFrameOfPresentedView
+NS_DESIGNATED_INITIALIZER;
+
+/**
+ The presentation controller's scrim view.
+ */
+@property(nonatomic, strong, nullable, readonly) UIView * scrimView;
+
+/**
+ The animation controller is able to customize animations in reaction to view controller
+ presentation and dismissal events.
+
+ The animation controller is explicitly nil'd upon completion of the dismissal transition.
+ */
+@property(nonatomic, strong, nullable) id <MDMTransitionPresentationAnimationControlling> animationController;
+
+@end
+
+/**
+ An animation controller receives additional presentation- and dismissal-related events during a
+ view controller transition.
+ */
+NS_SWIFT_NAME(TransitionPresentationAnimationControlling)
+@protocol MDMTransitionPresentationAnimationControlling <NSObject>
+@optional
+
+/**
+ Allows the receiver to register animations for the given transition context.
+
+ Invoked prior to the Transition instance's startWithContext.
+ 
+ If not implemented, the scrim view will be faded in during presentation and out during dismissal.
+ */
+- (void)presentationController:(nonnull MDMTransitionPresentationController *)presentationController
+              startWithContext:(nonnull NSObject<MDMTransitionContext> *)context;
+
+/**
+ Informs the receiver that the dismissal transition is about to begin.
+ */
+- (void)dismissalTransitionWillBeginWithPresentationController:(nonnull MDMTransitionPresentationController *)presentationController;
+
+/**
+ Informs the receiver that the dismissal transition has completed.
+ */
+- (void)presentationController:(nonnull MDMTransitionPresentationController *)presentationController
+     dismissalTransitionDidEnd:(BOOL)completed;
+
+@end

--- a/src/MDMTransitionPresentationController.m
+++ b/src/MDMTransitionPresentationController.m
@@ -1,0 +1,120 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMTransitionPresentationController.h"
+
+#import "MDMTransition.h"
+#import "MDMTransitionContext.h"
+#import "MDMTransitionController.h"
+#import "UIViewController+TransitionController.h"
+
+@interface MDMTransitionPresentationController () <MDMTransition>
+@end
+
+@implementation MDMTransitionPresentationController {
+  CGRect (^_calculateFrameOfPresentedView)(UIPresentationController *);
+}
+
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
+                       presentingViewController:(UIViewController *)presentingViewController
+                  calculateFrameOfPresentedView:(MDMTransitionFrameCalculation)calculateFrameOfPresentedView {
+  self = [super initWithPresentedViewController:presentedViewController
+                       presentingViewController:presentingViewController];
+  if (self) {
+    _calculateFrameOfPresentedView = [calculateFrameOfPresentedView copy];
+  }
+  return self;
+}
+
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController presentingViewController:(UIViewController *)presentingViewController {
+  return [self initWithPresentedViewController:presentedViewController
+                      presentingViewController:presentingViewController
+                 calculateFrameOfPresentedView:nil];
+}
+
+- (CGRect)frameOfPresentedViewInContainerView {
+  if (_calculateFrameOfPresentedView) {
+    return _calculateFrameOfPresentedView(self);
+  } else {
+    return self.containerView.bounds;
+  }
+}
+
+- (BOOL)shouldRemovePresentersView {
+  // We don't have access to the container view when this method is called, so we can only guess as
+  // to whether we'll be presenting full screen by checking for the presence of a frame calculation
+  // block.
+  BOOL definitelyFullscreen = _calculateFrameOfPresentedView == nil;
+
+  // Returning true here will cause UIKit to invoke viewWillDisappear and viewDidDisappear on the
+  // presenting view controller, and the presenting view controller's view will be removed on
+  // completion of the transition.
+  return definitelyFullscreen;
+}
+
+- (void)dismissalTransitionWillBegin {
+  if (!self.presentedViewController.mdm_transitionController.activeTransition) {
+    [self.presentedViewController.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      self.scrimView.alpha = 0;
+    } completion:nil];
+
+    if ([self.animationController respondsToSelector:@selector(dismissalTransitionWillBeginWithPresentationController:)]) {
+      [self.animationController dismissalTransitionWillBeginWithPresentationController:self];
+    }
+  }
+}
+
+- (void)dismissalTransitionDidEnd:(BOOL)completed {
+  if (completed) {
+    [self.scrimView removeFromSuperview];
+    _scrimView = nil;
+
+  } else {
+    self.scrimView.alpha = 1;
+  }
+
+  if ([self.animationController respondsToSelector:@selector(presentationController:dismissalTransitionDidEnd:)]) {
+    [self.animationController presentationController:self dismissalTransitionDidEnd:completed];
+  }
+
+  if (completed) {
+    // Break any potential memory cycles due to our strong ownership of the animation controller.
+    self.animationController = nil;
+  }
+}
+
+- (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
+  if (!self.scrimView) {
+    _scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
+    self.scrimView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
+                                       | UIViewAutoresizingFlexibleHeight);
+    self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3f];
+    [context.containerView insertSubview:self.scrimView
+                            belowSubview:context.foreViewController.view];
+  }
+
+  if ([self.animationController respondsToSelector:@selector(presentationController:startWithContext:)]) {
+    [self.animationController presentationController:self startWithContext:context];
+  } else {
+    self.scrimView.alpha = context.direction == MDMTransitionDirectionForward ? 0 : 1;
+
+    [UIView animateWithDuration:context.duration animations:^{
+      self.scrimView.alpha = context.direction == MDMTransitionDirectionForward ? 1 : 0;
+    }];
+  }
+}
+
+@end

--- a/src/MotionTransitioning.h
+++ b/src/MotionTransitioning.h
@@ -18,4 +18,5 @@
 #import "MDMTransitionContext.h"
 #import "MDMTransitionController.h"
 #import "MDMTransitionNavigationControllerDelegate.h"
+#import "MDMTransitionPresentationController.h"
 #import "UIViewController+TransitionController.h"

--- a/src/UIViewController+TransitionController.m
+++ b/src/UIViewController+TransitionController.m
@@ -16,7 +16,7 @@
 
 #import "UIViewController+TransitionController.h"
 
-#import "private/MDMPresentationTransitionController.h"
+#import "private/MDMViewControllerTransitionController.h"
 
 #import <objc/runtime.h>
 
@@ -27,9 +27,9 @@
 - (id<MDMTransitionController>)mdm_transitionController {
   const void *key = [self mdm_transitionControllerKey];
 
-  MDMPresentationTransitionController *controller = objc_getAssociatedObject(self, key);
+  MDMViewControllerTransitionController *controller = objc_getAssociatedObject(self, key);
   if (!controller) {
-    controller = [[MDMPresentationTransitionController alloc] initWithViewController:self];
+    controller = [[MDMViewControllerTransitionController alloc] initWithViewController:self];
     [self mdm_setTransitionController:controller];
   }
   return controller;
@@ -37,11 +37,11 @@
 
 #pragma mark - Private
 
-- (void)mdm_setTransitionController:(MDMPresentationTransitionController *)controller {
+- (void)mdm_setTransitionController:(MDMViewControllerTransitionController *)controller {
   const void *key = [self mdm_transitionControllerKey];
 
   // Clear the previous delegate if we'd previously set one.
-  MDMPresentationTransitionController *existingController = objc_getAssociatedObject(self, key);
+  MDMViewControllerTransitionController *existingController = objc_getAssociatedObject(self, key);
   id<UIViewControllerTransitioningDelegate> delegate = self.transitioningDelegate;
   if (existingController == delegate) {
     self.transitioningDelegate = nil;

--- a/src/private/MDMViewControllerTransitionContext.m
+++ b/src/private/MDMViewControllerTransitionContext.m
@@ -69,7 +69,7 @@
 
 // TODO(featherless): Implement interactive transitioning. Need to implement
 // UIViewControllerInteractiveTransitioning here and isInteractive and interactionController* in
-// MDMPresentationTransitionController.
+// MDMViewControllerTransitionController.
 
 #pragma mark - MDMTransitionContext
 

--- a/src/private/MDMViewControllerTransitionController.h
+++ b/src/private/MDMViewControllerTransitionController.h
@@ -19,7 +19,7 @@
 
 #import "MDMTransitionController.h"
 
-@interface MDMPresentationTransitionController : NSObject <MDMTransitionController, UIViewControllerTransitioningDelegate>
+@interface MDMViewControllerTransitionController : NSObject <MDMTransitionController, UIViewControllerTransitioningDelegate>
 
 - (nonnull instancetype)initWithViewController:(nonnull UIViewController *)viewController
     NS_DESIGNATED_INITIALIZER;

--- a/src/private/MDMViewControllerTransitionController.m
+++ b/src/private/MDMViewControllerTransitionController.m
@@ -14,15 +14,15 @@
  limitations under the License.
  */
 
-#import "MDMPresentationTransitionController.h"
+#import "MDMViewControllerTransitionController.h"
 
 #import "MDMTransition.h"
 #import "MDMViewControllerTransitionContext.h"
 
-@interface MDMPresentationTransitionController () <UIViewControllerTransitioningDelegate, MDMViewControllerTransitionContextDelegate>
+@interface MDMViewControllerTransitionController () <UIViewControllerTransitioningDelegate, MDMViewControllerTransitionContextDelegate>
 @end
 
-@implementation MDMPresentationTransitionController {
+@implementation MDMViewControllerTransitionController {
   // We expect the view controller to hold a strong reference to its transition controller, so keep
   // a weak reference to the view controller here.
   __weak UIViewController *_associatedViewController;


### PR DESCRIPTION
Also updated the examples accordingly by removing the custom presentation controller.

This will replace the Material Components for iOS [MaskedTransition](https://github.com/material-components/material-components-ios/tree/develop/components/MaskedTransition) presentation controller [implementation](https://github.com/material-components/material-components-ios/blob/develop/components/MaskedTransition/src/private/MDCMaskedPresentationController.m).

Also renamed MDMPresentationTransitionController to MDMViewControllerTransitionController in order to disambiguate the private class' name from the new public API.