### PR TITLE
Explicitly include void for block parameters.

### DIFF
--- a/src/MDMTransitionContext.h
+++ b/src/MDMTransitionContext.h
@@ -91,6 +91,6 @@ NS_SWIFT_NAME(TransitionContext)
 
  Upon completion, each block of work will be executed in the order it was provided to the context.
  */
-- (void)deferToCompletion:(void (^ _Nonnull)())work;
+- (void)deferToCompletion:(void (^ _Nonnull)(void))work;
 
 @end

--- a/src/private/MDMViewControllerTransitionContext.m
+++ b/src/private/MDMViewControllerTransitionContext.m
@@ -96,7 +96,7 @@
   [_delegate transitionDidCompleteWithContext:self];
 }
 
-- (void)deferToCompletion:(void (^)())work {
+- (void)deferToCompletion:(void (^)(void))work {
   [_completionBlocks addObject:[work copy]];
 }
 


### PR DESCRIPTION
This fixes an issue when building material-components.