### PR TITLE
Add support for transitions with custom presented views.

### DIFF
--- a/src/private/MDMViewControllerTransitionCoordinator.m
+++ b/src/private/MDMViewControllerTransitionCoordinator.m
@@ -313,34 +313,42 @@
   _root.transitionContext = _transitionContext;
 
   UIViewController *from = [_transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
-  if (from) {
+  UIView *fromView = [_transitionContext viewForKey:UITransitionContextFromViewKey];
+  if (fromView == nil) {
+    fromView = from.view;
+  }
+  if (fromView != nil && fromView == from.view) {
     CGRect finalFrame = [_transitionContext finalFrameForViewController:from];
     if (!CGRectIsEmpty(finalFrame)) {
-      from.view.frame = finalFrame;
+      fromView.frame = finalFrame;
     }
   }
 
   UIViewController *to = [_transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-  if (to) {
+  UIView *toView = [_transitionContext viewForKey:UITransitionContextToViewKey];
+  if (toView == nil) {
+    toView = to.view;
+  }
+  if (toView != nil && toView == to.view) {
     CGRect finalFrame = [_transitionContext finalFrameForViewController:to];
     if (!CGRectIsEmpty(finalFrame)) {
-      to.view.frame = finalFrame;
+      toView.frame = finalFrame;
     }
 
-    switch (_direction) {
-      case MDMTransitionDirectionForward:
-        [_transitionContext.containerView addSubview:to.view];
-        break;
+    if (toView.superview == nil) {
+      switch (_direction) {
+        case MDMTransitionDirectionForward:
+          [_transitionContext.containerView addSubview:toView];
+          break;
 
-      case MDMTransitionDirectionBackward:
-        if (!to.view.superview) {
-          [_transitionContext.containerView insertSubview:to.view atIndex:0];
-        }
-        break;
+        case MDMTransitionDirectionBackward:
+          [_transitionContext.containerView insertSubview:toView atIndex:0];
+          break;
+      }
     }
-
-    [to.view layoutIfNeeded];
   }
+
+  [toView layoutIfNeeded];
 
   [_root attemptFallback];
   [self anticipateOnlyExplicitAnimations];


### PR DESCRIPTION
If the transition's presentation controller implements `-presentedView`, it's possible that `viewForKey:` will not return the view of either of the fore/back view controllers. This type of behavior is often implemented if the presented view controller's view is being embedded inside of another view.

In order to support this behavior, we must use the viewForKey: API to fetch the desired view. If that view matches the view controller's view, then we can set the view's frame to the view controller's destination frame as we had been doing before. Otherwise, we make no modifications to the view's frame.

This feature will be used to implement the BottomSheet component using MotionTransitioning.