### PR TITLE
Add unit tests verifying that the presented controller's frame matches the expected frame

### DIFF
--- a/tests/unit/TransitionWithPresentationTests.swift
+++ b/tests/unit/TransitionWithPresentationTests.swift
@@ -32,7 +32,7 @@ class TransitionWithPresentationTests: XCTestCase {
 
   func testPresentationControllerIsQueriedAndCompletesWithoutAnimation() {
     let presentedViewController = UIViewController()
-    presentedViewController.mdm_transitionController.transition = PresentationTransition()
+    presentedViewController.mdm_transitionController.transition = TestingPresentationTransition()
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: false) {
@@ -46,7 +46,7 @@ class TransitionWithPresentationTests: XCTestCase {
 
   func testPresentationControllerIsQueriedAndCompletesWithAnimation() {
     let presentedViewController = UIViewController()
-    presentedViewController.mdm_transitionController.transition = PresentationTransition()
+    presentedViewController.mdm_transitionController.transition = TestingPresentationTransition()
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {
@@ -72,12 +72,13 @@ class TransitionWithPresentationTests: XCTestCase {
     waitForExpectations(timeout: 0.1)
 
     XCTAssertEqual(window.rootViewController!.presentedViewController, presentedViewController)
-    XCTAssertEqual(window.rootViewController!.presentedViewController?.view.bounds, window.bounds)
+    XCTAssertEqual(window.rootViewController!.presentedViewController?.view.bounds,
+                   window.rootViewController!.view.bounds)
   }
 
   func testPresentedFrameMatchesPresentationFrame() {
     let presentedViewController = UIViewController()
-    let transition = PresentationTransition()
+    let transition = TestingPresentationTransition()
     transition.presentationFrame = CGRect(x: 100, y: 30, width: 50, height: 70)
     presentedViewController.transitionController.transition = transition
 
@@ -96,8 +97,9 @@ class TransitionWithPresentationTests: XCTestCase {
 
   func testNoFramesModifiedWhenThereIsAPresentationView() {
     let presentedViewController = UIViewController()
-    let transition = PresentationTransition()
-    let presentationView = UIView()
+    let transition = TestingPresentationTransition()
+    let presentationFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let presentationView = UIView(frame: presentationFrame)
     transition.presentationView = presentationView
     presentedViewController.transitionController.transition = transition
 
@@ -110,7 +112,7 @@ class TransitionWithPresentationTests: XCTestCase {
     waitForExpectations(timeout: 0.1)
 
     XCTAssertEqual(window.rootViewController!.presentedViewController, presentedViewController)
-    XCTAssertEqual(presentationView.frame, .zero)
+    XCTAssertEqual(presentationView.frame, presentationFrame)
     XCTAssertEqual(presentedViewController.view.frame, UIScreen.main.bounds)
   }
 }
@@ -138,7 +140,7 @@ final class TestingPresentationController: UIPresentationController {
   }
 }
 
-final class PresentationTransition: NSObject, TransitionWithPresentation {
+final class TestingPresentationTransition: NSObject, TransitionWithPresentation {
   var presentationFrame: CGRect?
   var presentationView: UIView?
 

--- a/tests/unit/TransitionWithPresentationTests.swift
+++ b/tests/unit/TransitionWithPresentationTests.swift
@@ -32,8 +32,21 @@ class TransitionWithPresentationTests: XCTestCase {
 
   func testPresentationControllerIsQueriedAndCompletesWithoutAnimation() {
     let presentedViewController = UIViewController()
-    presentedViewController.mdm_transitionController.transition =
-      PresentationTransition(presentationControllerType: TestingPresentationController.self)
+    presentedViewController.mdm_transitionController.transition = PresentationTransition()
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: false) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.5)
+
+    XCTAssert(presentedViewController.presentationController is TestingPresentationController)
+  }
+
+  func testPresentationControllerIsQueriedAndCompletesWithAnimation() {
+    let presentedViewController = UIViewController()
+    presentedViewController.mdm_transitionController.transition = PresentationTransition()
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {
@@ -45,39 +58,65 @@ class TransitionWithPresentationTests: XCTestCase {
     XCTAssert(presentedViewController.presentationController is TestingPresentationController)
   }
 
-  func testPresentationControllerIsQueriedAndCompletesWithAnimation() {
+  func testPresentedFrameMatchesWindowFrame() {
     let presentedViewController = UIViewController()
-    presentedViewController.mdm_transitionController.transition =
-      PresentationTransition(presentationControllerType: TransitionPresentationController.self)
+    let transition = InstantCompletionTransition()
+    presentedViewController.transitionController.transition = transition
 
     let didComplete = expectation(description: "Did complete")
+    window.frame = CGRect(x: 0, y: 0, width: 300, height: 200)
     window.rootViewController!.present(presentedViewController, animated: true) {
       didComplete.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5)
+    waitForExpectations(timeout: 0.1)
 
-    XCTAssert(presentedViewController.presentationController is TransitionPresentationController)
+    XCTAssertEqual(window.rootViewController!.presentedViewController, presentedViewController)
+    XCTAssertEqual(window.rootViewController!.presentedViewController?.view.bounds, window.bounds)
+  }
+
+  func testPresentedFrameMatchesPresentationFrame() {
+    let presentedViewController = UIViewController()
+    let transition = PresentationTransition()
+    transition.presentationFrame = CGRect(x: 100, y: 30, width: 50, height: 70)
+    presentedViewController.transitionController.transition = transition
+
+    let didComplete = expectation(description: "Did complete")
+    window.frame = CGRect(x: 0, y: 0, width: 300, height: 200)
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(window.rootViewController!.presentedViewController, presentedViewController)
+    XCTAssertEqual(window.rootViewController!.presentedViewController?.view.frame,
+                   transition.presentationFrame)
   }
 }
 
 final class TestingPresentationController: UIPresentationController {
+  var presentationFrame: CGRect?
+  override var frameOfPresentedViewInContainerView: CGRect {
+    if let presentationFrame = presentationFrame {
+      return presentationFrame
+    }
+    return super.frameOfPresentedViewInContainerView
+  }
 }
 
 final class PresentationTransition: NSObject, TransitionWithPresentation {
-  let presentationControllerType: UIPresentationController.Type
-  init(presentationControllerType: UIPresentationController.Type) {
-    self.presentationControllerType = presentationControllerType
-
-    super.init()
-  }
+  var presentationFrame: CGRect?
 
   func defaultModalPresentationStyle() -> UIModalPresentationStyle {
     return .custom
   }
 
   func presentationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController?) -> UIPresentationController? {
-    return presentationControllerType.init(presentedViewController: presented, presenting: presenting)
+    let presentationController =
+      TestingPresentationController(presentedViewController: presented, presenting: presenting)
+    presentationController.presentationFrame = presentationFrame
+    return presentationController
   }
 
   func start(with context: TransitionContext) {


### PR DESCRIPTION
This is a follow-up to #55.

Also fixes an existing test that said it was testing the non-animated route.