### PR TITLE
[breaking] Rename the transitionController Swift API to mdm_transitionController.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ you can pick the custom transition you want to use:
 
 ```swift
 let viewController = MyViewController()
-viewController.transitionController.transition = CustomTransition()
+viewController.mdm_transitionController.transition = CustomTransition()
 present(viewController, animated: true)
 ```
 
@@ -129,7 +129,7 @@ and dismissal of our view controller:
 
 ```swift
 let viewController = MyViewController()
-viewController.transitionController.transition = FadeTransition()
+viewController.mdm_transitionController.transition = FadeTransition()
 present(viewController, animated: true)
 ```
 

--- a/examples/ContextualExample.swift
+++ b/examples/ContextualExample.swift
@@ -35,7 +35,7 @@ class ContextualExampleViewController: ExampleViewController {
     // Note that in this example we're populating the contextual transition with the tapped view.
     // Our rudimentary transition will animate the context view to the center of the screen from its
     // current location.
-    controller.transitionController.transition = CompositeTransition(transitions: [
+    controller.mdm_transitionController.transition = CompositeTransition(transitions: [
       FadeTransition(target: .foreView),
       ContextualTransition(contextView: tapGesture.view!)
     ])

--- a/examples/CustomPresentationExample.swift
+++ b/examples/CustomPresentationExample.swift
@@ -165,7 +165,7 @@ extension CustomPresentationExampleViewController {
 extension CustomPresentationExampleViewController {
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     let modal = ModalViewController()
-    modal.transitionController.transition = transitions[indexPath.row].transition
+    modal.mdm_transitionController.transition = transitions[indexPath.row].transition
     showDetailViewController(modal, sender: self)
   }
 }

--- a/examples/FadeExample.swift
+++ b/examples/FadeExample.swift
@@ -30,7 +30,7 @@ class FadeExampleViewController: ExampleViewController {
     // controller that you'll make use of is the `transition` property. Setting this property will
     // dictate how the view controller is presented. For this example we've built a custom
     // FadeTransition, so we'll make use of that now:
-    modalViewController.transitionController.transition = FadeTransition(target: .foreView)
+    modalViewController.mdm_transitionController.transition = FadeTransition(target: .foreView)
 
     // Note that once we assign the transition object to the view controller, the transition will
     // govern all subsequent presentations and dismissals of that view controller instance. If we

--- a/examples/MenuExample.swift
+++ b/examples/MenuExample.swift
@@ -21,7 +21,7 @@ class MenuExampleViewController: ExampleViewController {
 
   func didTap() {
     let modalViewController = ModalViewController()
-    modalViewController.transitionController.transition = MenuTransition()
+    modalViewController.mdm_transitionController.transition = MenuTransition()
     present(modalViewController, animated: true)
   }
 

--- a/examples/NavControllerFadeExample.swift
+++ b/examples/NavControllerFadeExample.swift
@@ -31,7 +31,7 @@ class NavControllerFadeExampleViewController: ExampleViewController {
     // controller that you'll make use of is the `transition` property. Setting this property will
     // dictate how the view controller is presented. For this example we've built a custom
     // FadeTransition, so we'll make use of that now:
-    modalViewController.transitionController.transition = FadeTransition(target: .foreView)
+    modalViewController.mdm_transitionController.transition = FadeTransition(target: .foreView)
 
     cachedNavDelegate = navigationController?.delegate
 

--- a/examples/PhotoAlbumExample.swift
+++ b/examples/PhotoAlbumExample.swift
@@ -73,7 +73,7 @@ public class PhotoAlbumExampleViewController: UICollectionViewController, PhotoA
   public override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     let viewController = PhotoAlbumViewController(album: album)
     viewController.currentPhoto = album.photos[indexPath.row]
-    viewController.transitionController.transition = PhotoAlbumTransition(backDelegate: self,
+    viewController.mdm_transitionController.transition = PhotoAlbumTransition(backDelegate: self,
                                                                           foreDelegate: viewController)
     present(viewController, animated: true)
   }

--- a/src/UIViewController+TransitionController.h
+++ b/src/UIViewController+TransitionController.h
@@ -29,7 +29,6 @@
  Side effects: If the view controller's transitioningDelegate is nil when the controller is created,
  then the controller will also be set to the transitioningDelegate property.
  */
-@property(nonatomic, strong, readonly, nonnull) id<MDMTransitionController> mdm_transitionController
-    NS_SWIFT_NAME(transitionController);
+@property(nonatomic, strong, readonly, nonnull) id<MDMTransitionController> mdm_transitionController;
 
 @end

--- a/tests/unit/TransitionTests.swift
+++ b/tests/unit/TransitionTests.swift
@@ -32,7 +32,7 @@ class TransitionTests: XCTestCase {
 
   func testTransitionDidEndDoesComplete() {
     let presentedViewController = UIViewController()
-    presentedViewController.transitionController.transition = InstantCompletionTransition()
+    presentedViewController.mdm_transitionController.transition = InstantCompletionTransition()
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {
@@ -46,7 +46,7 @@ class TransitionTests: XCTestCase {
 
   func testTransitionCompositionDoesComplete() {
     let presentedViewController = UIViewController()
-    presentedViewController.transitionController.transition = CompositeTransition(transitions: [
+    presentedViewController.mdm_transitionController.transition = CompositeTransition(transitions: [
       InstantCompletionTransition(),
       InstantCompletionTransition()
     ])
@@ -64,7 +64,7 @@ class TransitionTests: XCTestCase {
   func testTransitionFallbackToOtherTransitionDoesComplete() {
     let presentedViewController = UIViewController()
     let transition = FallbackTransition(to: InstantCompletionTransition())
-    presentedViewController.transitionController.transition = transition
+    presentedViewController.mdm_transitionController.transition = transition
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {
@@ -80,7 +80,7 @@ class TransitionTests: XCTestCase {
   func testTransitionFallbackToSelfDoesComplete() {
     let presentedViewController = UIViewController()
     let transition = FallbackTransition()
-    presentedViewController.transitionController.transition = transition
+    presentedViewController.mdm_transitionController.transition = transition
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {

--- a/tests/unit/TransitionWithCustomDurationTests.swift
+++ b/tests/unit/TransitionWithCustomDurationTests.swift
@@ -60,7 +60,7 @@ class TransitionWithCustomDurationTests: XCTestCase {
   func testDefaultDurationIsProvidedViaContext() {
     let presentedViewController = UIViewController()
     let transition = DurationMemoryTransition()
-    presentedViewController.transitionController.transition = transition
+    presentedViewController.mdm_transitionController.transition = transition
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {
@@ -79,7 +79,7 @@ class TransitionWithCustomDurationTests: XCTestCase {
     let presentedViewController = UIViewController()
     let customDuration: TimeInterval = 0.1
     let transition = CustomDurationMemoryTransition(with: customDuration)
-    presentedViewController.transitionController.transition = transition
+    presentedViewController.mdm_transitionController.transition = transition
 
     let didComplete = expectation(description: "Did complete")
     window.rootViewController!.present(presentedViewController, animated: true) {

--- a/tests/unit/TransitionWithPresentationTests.swift
+++ b/tests/unit/TransitionWithPresentationTests.swift
@@ -32,7 +32,7 @@ class TransitionWithPresentationTests: XCTestCase {
 
   func testPresentationControllerIsQueriedAndCompletesWithoutAnimation() {
     let presentedViewController = UIViewController()
-    presentedViewController.transitionController.transition =
+    presentedViewController.mdm_transitionController.transition =
       PresentationTransition(presentationControllerType: TestingPresentationController.self)
 
     let didComplete = expectation(description: "Did complete")
@@ -47,7 +47,7 @@ class TransitionWithPresentationTests: XCTestCase {
 
   func testPresentationControllerIsQueriedAndCompletesWithAnimation() {
     let presentedViewController = UIViewController()
-    presentedViewController.transitionController.transition =
+    presentedViewController.mdm_transitionController.transition =
       PresentationTransition(presentationControllerType: TransitionPresentationController.self)
 
     let didComplete = expectation(description: "Did complete")


### PR DESCRIPTION
This avoids creating naming conflicts with local variables defined in view controllers with a similar name.

This is blocking https://github.com/material-components/material-components-ios/pull/2506.