### PR TITLE
Update bazel workspace to latest versions.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -20,7 +20,43 @@ set -e
 # Display commands to stderr.
 set -x
 
-KOKORO_RUNNER_VERSION="v3.*"
+BAZEL_VERSION="0.20.0"
+IOS_MINIMUM_OS="8.0"
+IOS_CPUS="i386,x86_64"
+
+get_xcode_version_from_path() {
+  path="$1"
+  cat "$path/version.plist" \
+    | grep "CFBundleShortVersionString" -A1 \
+    | grep string \
+    | cut -d'>' -f2 \
+    | cut -d'<' -f1
+}
+
+run_bazel() {
+  echo "Running bazel builds..."
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    bazel version
+    use_bazel.sh "$BAZEL_VERSION"
+    bazel version
+
+    # Move into our cloned repo
+    cd github/repo
+  fi
+
+  # Run against whichever Xcode is currently selected.
+  selected_xcode_developer_path=$(xcode-select -p)
+  selected_xcode_contents_path=$(dirname "$selected_xcode_developer_path")
+
+  xcode_version=$(get_xcode_version_from_path "$selected_xcode_contents_path")
+
+  bazel clean
+  bazel test //... \
+    --xcode_version "$xcode_version" \
+    --ios_minimum_os="$IOS_MINIMUM_OS" \
+    --ios_multi_cpus="$IOS_CPUS"
+}
 
 fix_bazel_imports() {
   if [ -z "$KOKORO_BUILD_NUMBER" ]; then
@@ -39,18 +75,7 @@ fix_bazel_imports() {
   trap reset_imports EXIT
 }
 
-if [ ! -d .kokoro-ios-runner ]; then
-  git clone https://github.com/material-foundation/kokoro-ios-runner.git .kokoro-ios-runner
-fi
-
-pushd .kokoro-ios-runner
-git fetch > /dev/null
-TAG=$(git tag --sort=v:refname -l "$KOKORO_RUNNER_VERSION" | tail -n1)
-git checkout "$TAG" > /dev/null
-popd
-
 fix_bazel_imports
-
-./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
+run_bazel
 
 echo "Success!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ matrix:
       env: SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6s,OS=10.3.1"
     - osx_image: xcode9.2
       env: SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6s,OS=9.3"
-    - osx_image: xcode9.2
-      env: SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6,OS=8.4"
-    - osx_image: xcode8.3
-      env: SDK="iphonesimulator10.3" DESTINATION="name=iPhone 6,OS=8.1"
 before_install:
   - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
   - pod install --repo-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
 language: objective-c
-osx_image: xcode8.1
 sudo: false
+env:
+  global:
+  - LC_CTYPE=en_US.UTF-8
+  - LANG=en_US.UTF-8
+  - LANGUAGE=en_US.UTF-8
+matrix:
+  include:
+    - osx_image: xcode9.2
+      env: COVERAGE=code_coverage SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6s,OS=11.2"
+    - osx_image: xcode9.2
+      env: SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6s,OS=10.3.1"
+    - osx_image: xcode9.2
+      env: SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6s,OS=9.3"
+    - osx_image: xcode9.2
+      env: SDK="iphonesimulator11.2" DESTINATION="name=iPhone 6,OS=8.4"
+    - osx_image: xcode8.3
+      env: SDK="iphonesimulator10.3" DESTINATION="name=iPhone 6,OS=8.1"
 before_install:
   - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
   - pod install --repo-update
 script:
   - set -o pipefail
-  - xcodebuild build -workspace MotionTransitioning.xcworkspace -scheme TransitionsCatalog -sdk "iphonesimulator10.1" -destination "name=iPhone 6s,OS=10.1" ONLY_ACTIVE_ARCH=YES | xcpretty -c;
+  - xcodebuild test -workspace MotionTransitioning.xcworkspace -scheme TransitionsCatalog -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=YES | xcpretty -c;
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,8 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_ui_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 
 strict_warnings_objc_library(
@@ -35,8 +37,6 @@ strict_warnings_objc_library(
     includes = ["src"],
     visibility = ["//visibility:public"],
 )
-
-load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 swift_library(
     name = "UnitTestsSwiftLib",
@@ -57,14 +57,13 @@ objc_library(
     visibility = ["//visibility:private"],
 )
 
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
-
-ios_unit_test(
+ios_ui_test(
     name = "UnitTests",
     deps = [
       ":UnitTestsLib",
       ":UnitTestsSwiftLib"
     ],
+    test_host = "@build_bazel_rules_apple//apple/testing/default_host/ios",
     minimum_os_version = "8.0",
     timeout = "short",
     visibility = ["//visibility:private"],

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,14 +6,18 @@ DEPENDENCIES:
   - CatalogByConvention
   - MotionTransitioning (from `./`)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CatalogByConvention
+
 EXTERNAL SOURCES:
   MotionTransitioning:
-    :path: ./
+    :path: "./"
 
 SPEC CHECKSUMS:
   CatalogByConvention: c3a5319de04250a7cd4649127fcfca5fe3322a43
-  MotionTransitioning: 23d25edc2f4606efb922403cbac6d81af37aa33a
+  MotionTransitioning: 42968eefaeb185d70dad5d891bf1229e84c0ccc9
 
 PODFILE CHECKSUM: 25d5942fb7698339a03667bb46c3fbb77529b92d
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,14 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "7ea0557",
+    tag = "0.9.0",
 )
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+git_repository(
+    name = "build_bazel_rules_swift",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+    tag = "0.4.0",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
 
 git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
-    tag = "v1.0.1",
+    tag = "v2.0.0",
+)
+
+http_file(
+    name = "xctestrunner",
+    executable = 1,
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.5/ios_test_runner.par"],
 )

--- a/examples/apps/Catalog/TransitionsCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/TransitionsCatalog.xcodeproj/project.pbxproj
@@ -369,7 +369,6 @@
 				666FAA7E1D384A6B000363DA /* Resources */,
 				332B5EA9D6D03DB5A5EC0149 /* Frameworks */,
 				EBE92D1BA3D06BD67925A4E0 /* [CP] Embed Pods Frameworks */,
-				8FFB1F82A9D08AF069E44DFB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -389,7 +388,6 @@
 				666FAA921D384A6B000363DA /* Resources */,
 				03BB10DAA9B410FC78A061DE /* Frameworks */,
 				B07B7D3E33EA12345D5D53CC /* [CP] Embed Pods Frameworks */,
-				560BE48F7F0BF2FEBC8AF290 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -494,36 +492,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		560BE48F7F0BF2FEBC8AF290 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../../../Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8FFB1F82A9D08AF069E44DFB /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../../../Pods/Target Support Files/Pods-TransitionsCatalog/Pods-TransitionsCatalog-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		98D73D231683AA2871B76D81 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
This increases the following versions:

- bazel from 0.11 to 0.20.0
- build_bazel_rules_apple from 7ea0557 to 0.9.0
- build_bazel_rules_swift to 0.4.0 (new)
- bazel_ios_warnings from v1.0.1 to v2.0.0
- Xcode from 8 to 9.
- Swift pinned to 3.
- Unit test upgraded to UI tests.
- Add 9.3 and 11.2 OS to the travis CI matrix.
- Migrate from the bazel runner scripts to the explicit Xcode selection + run pattern used by material-components-ios (https://github.com/material-components/material-components-ios/blob/fe0099d65c4fa67a02d7b842baf16b540bb2fa86/.kokoro#L102)