### PR TITLE
Always add the toView to the container.

### DIFF
--- a/src/private/MDMViewControllerTransitionCoordinator.m
+++ b/src/private/MDMViewControllerTransitionCoordinator.m
@@ -336,17 +336,17 @@
     if (!CGRectIsEmpty(finalFrame)) {
       toView.frame = finalFrame;
     }
+  }
 
-    if (toView.superview == nil) {
-      switch (_direction) {
-        case MDMTransitionDirectionForward:
-          [_transitionContext.containerView addSubview:toView];
-          break;
+  if (toView.superview == nil) {
+    switch (_direction) {
+      case MDMTransitionDirectionForward:
+        [_transitionContext.containerView addSubview:toView];
+        break;
 
-        case MDMTransitionDirectionBackward:
-          [_transitionContext.containerView insertSubview:toView atIndex:0];
-          break;
-      }
+      case MDMTransitionDirectionBackward:
+        [_transitionContext.containerView insertSubview:toView atIndex:0];
+        break;
     }
   }
 


### PR DESCRIPTION
On iOS 13, the to view for default transitions has changed from the view controller to a container view.

Prior to this change, this meant that our transitions would not add the "to" view to the view hierarchy, resulting in the transition getting in to a confusing visual state.

After this change, we always add the "to" view to the view hierarchy if it does not already have a parent.

Repro steps:

1. Open the catalog on an iOS 13 simulator/device.
2. Open the contextual transition example.
3. Tap the blue square.

Expected behavior: the transition completes, showing a pink view controller.

Actual behavior: the transition never appears to complete, and no pink view controller is shown.

| Before | After |
|:----|:----|
| ![Simulator Screen Shot - iPhone Xʀ - 2019-06-26 at 07 54 02](https://user-images.githubusercontent.com/45670/60177728-a439c600-97e7-11e9-8dea-39aecfd25ffe.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-06-26 at 07 53 21](https://user-images.githubusercontent.com/45670/60177723-9edc7b80-97e7-11e9-8c9f-08bf6f33dc3c.png) |
